### PR TITLE
Add HTTPS request support with OpenSSL and TCP networking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,19 @@ coding_o = $(lzss_o) \
 		  $(lz_deserialize_o) \
 		  $(lz_window_o)
 
+# Network
+
+CURRENT_CFLAGS := $(CFLAGS) $(COMMON_CFLAGS)
+$(eval $(call make_object, tcp_connection_o, $(SRC_DIR)/libs/network/tcp/tcp_connection.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
+$(eval $(call make_object, https_request_o, $(SRC_DIR)/libs/network/https/https_request.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
+
+network_o = $(https_request_o) \
+			$(tcp_connection_o)
+
+NETWORK_LFLAGS := -lssl
+
 # Dummy
+
 CURRENT_CFLAGS := $(CFLAGS) $(COMMON_CFLAGS) $(WINDOW_CFLAGS)
 $(eval $(call make_object, dummy_o, $(SRC_DIR)/apps/dummy/dummy.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
 
@@ -222,8 +234,8 @@ all_agent_o = $(agent_o) \
 			$(agent_request_o) \
 			$(agent_result_write_o)
 
-CURRENT_LFLAGS := $(LFLAGS)
-$(eval $(call make_executable, agent, $(common_o) $(all_agent_o), $(CURRENT_LFLAGS), $(BUILD_DIR)))
+CURRENT_LFLAGS := $(LFLAGS) $(NETWORK_LFLAGS)
+$(eval $(call make_executable, agent, $(common_o) $(network_o) $(all_agent_o), $(CURRENT_LFLAGS), $(BUILD_DIR)))
 agent: $(agent)
 
 all: snake dummy test agent

--- a/src/libs/network/https/https_request.c
+++ b/src/libs/network/https/https_request.c
@@ -1,0 +1,120 @@
+#include "https_request.h"
+#include "assert.h"
+#include "network/tcp/tcp_connection.h"
+#include "print.h"
+
+#include <openssl/ssl.h>
+
+static u8 ssl_write(SSL* ssl, void* begin, void* end) {
+    void* cursor = begin;
+    while (cursor < end) {
+        i32 r = SSL_write(ssl, cursor, bytesize(cursor, end));
+        if (r > 0) {
+            cursor = byteoffset(cursor, r);
+            debug_assert(cursor <= end);
+            continue;
+        }
+        i32 err = SSL_get_error(ssl, r);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) continue;
+        return 0;
+    }
+    return 1;
+}
+
+// Read the entire response (until connection closes)
+static void* ssl_read(stack_alloc* alloc, SSL* ssl) {
+    void* response_begin = alloc->cursor;
+    while (1) {
+        uptr size_remaining = bytesize(alloc->cursor, alloc->end);
+        if (size_remaining > 8192) { size_remaining = 8192; }
+        i32 r = SSL_read(ssl, alloc->cursor, size_remaining);
+        if (r > 0) {
+            alloc->cursor = byteoffset(alloc->cursor, r);
+        } else if (r == 0) {
+            // Clean EOF
+            break;
+        } else {
+            // Error
+            break;
+        }
+    }
+    return response_begin;
+}
+
+void* https_request_sync(stack_alloc* alloc, u8_slice host, u8_slice port, u8_slice request) {
+    void* begin = alloc->cursor;
+
+    print_string(file_stdout(), STRING("Request:\n"));
+    print_string(file_stdout(), (string){request.begin, request.end});
+    print_string(file_stdout(), STRING("----"));
+
+    struct {void* begin; void* end;} response;
+    response.begin = alloc->cursor;
+    response.end = alloc->cursor;
+
+    // Initialize OpenSSL
+    SSL_load_error_strings();
+    OpenSSL_add_ssl_algorithms();
+
+    const SSL_METHOD* method = TLS_client_method();
+    if (!method) {
+        goto deinit_method;
+    }
+
+    SSL_CTX* ctx = SSL_CTX_new(method);
+    if (!ctx) {
+        goto deinit_ssl_ctx;
+    }
+    SSL* ssl = SSL_new(ctx);
+    if (!ssl) {
+        goto deinit_ssl;
+    }
+
+    // Disable certifications for now
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+
+    file_t tcp = tcp_connect(host, port, alloc);
+    if (tcp == file_invalid()) {
+        goto deinit_tcp_connect;
+    }
+
+    SSL_set_fd(ssl, tcp);
+
+    void* host_null_terminated = sa_alloc(alloc, bytesize(host.begin, host.end) + 1);
+    sa_copy(alloc, host.begin, host_null_terminated, bytesize(host.begin, host.end));
+    *(u8*)byteoffset(host_null_terminated, bytesize(host.begin, host.end)) = '\0';
+    SSL_set_tlsext_host_name(ssl, host_null_terminated);
+    sa_free(alloc, host_null_terminated);
+
+    if (SSL_connect(ssl) != 1) {
+        goto deinit_ssl_connect;
+    }
+
+    // Send request
+    if (!ssl_write(ssl, request.begin, request.end)) {
+        int debug = 10;
+        unused(debug);
+    }
+
+    // Read the response
+    response.begin = ssl_read(alloc, ssl);
+    response.end = alloc->cursor;
+
+    // print_format(file_stdout(), STRING("%s\n"), (string){response.begin, response.end});
+
+    SSL_shutdown(ssl);
+deinit_ssl_connect:
+    tcp_close(tcp);
+deinit_tcp_connect:
+    SSL_free(ssl);
+deinit_ssl:
+    SSL_CTX_free(ctx);
+deinit_ssl_ctx:
+deinit_method:
+
+    sa_move_tail(alloc, response.begin, begin);
+
+    return begin;
+}
+
+

--- a/src/libs/network/https/https_request.h
+++ b/src/libs/network/https/https_request.h
@@ -1,0 +1,8 @@
+#ifndef HTTPS_REQUEST_H
+#define HTTPS_REQUEST_H
+
+#include "stack_alloc.h"
+
+void* https_request_sync(stack_alloc* alloc, u8_slice host, u8_slice port, u8_slice request);
+
+#endif

--- a/src/libs/network/tcp/tcp_connection.c
+++ b/src/libs/network/tcp/tcp_connection.c
@@ -1,0 +1,53 @@
+#include "tcp_connection.h"
+#include "mem.h"
+#include "print.h"
+
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+
+file_t tcp_connect(u8_slice host, u8_slice port, stack_alloc* alloc) {
+    struct addrinfo hints;
+    for  (u8* c = (u8*)&hints; c < (u8*)(&hints + 1); ++c) {*c = 0;}
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_protocol = IPPROTO_TCP;
+    
+    u8* host_null_terminated = sa_alloc(alloc, bytesize(host.begin, host.end) + 1);
+    sa_copy(alloc, host.begin, host_null_terminated, bytesize(host.begin, host.end));
+    host_null_terminated[bytesize(host.begin, host.end)] = '\0';
+
+    u8* port_null_terminated = sa_alloc(alloc, bytesize(port.begin, port.end) + 1);
+    sa_copy(alloc, port.begin, port_null_terminated, bytesize(port.begin, port.end));
+    port_null_terminated[bytesize(port.begin, port.end)] = '\0';
+
+    struct addrinfo* res = NULL;
+    int gai = getaddrinfo((const char*)host_null_terminated, (const char*)port_null_terminated, &hints, &res);
+    sa_free(alloc, port_null_terminated);
+    sa_free(alloc, host_null_terminated);
+
+    if (gai != 0) {
+        const char* error = gai_strerror(gai);
+        print_format(file_stdout(), STRING("%s\n"), (string){error, byteoffset(error, mem_cstrlen((void*)error))});
+        return file_invalid();
+    } 
+
+    int fd = file_invalid();
+    for (struct addrinfo* rp = res; rp; rp = rp->ai_next) {
+        fd = (int)socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
+            break; // success
+        }
+        close(fd);
+        fd = file_invalid();
+    }
+
+    freeaddrinfo(res);
+    return fd;
+}
+
+void tcp_close(file_t connection) {
+    close(connection);
+}
+

--- a/src/libs/network/tcp/tcp_connection.h
+++ b/src/libs/network/tcp/tcp_connection.h
@@ -1,0 +1,11 @@
+#ifndef TCP_CONNECTION_H
+#define TCP_CONNECTION_H
+
+#include "primitive.h"
+#include "stack_alloc.h"
+#include "file.h"
+
+file_t tcp_connect(u8_slice host, u8_slice port, stack_alloc* alloc);
+void tcp_close(file_t connection);
+
+#endif /*TCP_CONNECTION_H*/


### PR DESCRIPTION
- Introduced new network components:
  - tcp_connection.c / tcp_connection.h: TCP connection helpers (connect, close)
  - https_request.c / https_request.h: Synchronous HTTPS request function using OpenSSL
- Wired networking into build:
  - Added network_o and NETWORK_LFLAGS (-lssl)
  - Extended agent build to include network objects
- Created new files:
  - src/libs/network/https/https_request.c
  - src/libs/network/https/https_request.h
  - src/libs/network/tcp/tcp_connection.c
  - src/libs/network/tcp/tcp_connection.h

Notes:
- HTTPS client uses TLS client method, SSL_connect, and handles basic request/response flow.
- SSL verify is disabled for now (SSL_VERIFY_NONE).
- Basic OpenSSL initialization/cleanup added.