### PR TITLE
feat(network): add network tests and integrate test into build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ $(eval $(call make_object, test_backtrace_o, $(TESTS_DIR)/test_backtrace.c, $(CU
 $(eval $(call make_object, test_lzss_o, $(TESTS_DIR)/test_lzss.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
 $(eval $(call make_object, test_fps_ticker_o, $(TESTS_DIR)/test_fps_ticker.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
 $(eval $(call make_object, test_snake_o, $(TESTS_DIR)/test_snake.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
+$(eval $(call make_object, test_network_o, $(TESTS_DIR)/test_network.c, $(CURRENT_CFLAGS), , $(BUILD_DIR)))
 
 tests_o = $(all_tests_o) \
 	 	 $(test_mem_o) \
@@ -219,10 +220,11 @@ tests_o = $(all_tests_o) \
 	 	 $(test_backtrace_o) \
 	 	 $(test_lzss_o) \
 	 	 $(test_fps_ticker_o) \
-		 $(test_snake_o)
+		 $(test_snake_o) \
+		 $(test_network_o)
 
-CURRENT_LFLAGS := $(LFLAGS) $(WINDOW_LFLAGS)
-$(eval $(call make_executable, test, $(common_o) $(window_o) $(coding_o) $(snake_module_o) $(tests_o), $(CURRENT_LFLAGS), $(BUILD_DIR)))
+CURRENT_LFLAGS := $(LFLAGS) $(WINDOW_LFLAGS) $(NETWORK_LFLAGS)
+$(eval $(call make_executable, test, $(common_o) $(window_o) $(network_o) $(coding_o) $(snake_module_o) $(tests_o), $(CURRENT_LFLAGS), $(BUILD_DIR)))
 test: $(test)
 
 # Tools agent

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -8,6 +8,7 @@
 #include "test_backtrace.h"
 #include "test_fps_ticker.h"
 #include "test_snake.h"
+#include "test_network.h"
 
 #include "print.h"
 #include "file.h"
@@ -61,6 +62,7 @@ int main(int argc, char* argv[]) {
     test_lzss_module(ctx);
     test_fps_ticker_module(ctx);
     test_snake_module(ctx);
+    test_network_module(ctx);
 
     // Run filtered tests
     test_run_filtered(ctx);

--- a/tests/test_network.c
+++ b/tests/test_network.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "mem.h"
+#include "stack_alloc.h"
+#include "primitive.h"
+#include "network/tcp/tcp_connection.h"
+#include "network/https/https_request.h"
+#include "test_network.h"
+#include "print.h"
+
+/*
+    Tests for network layer:
+
+    - test_tcp_connect_success
+      Spins up a local TCP server on 127.0.0.1 with an ephemeral port.
+      Calls tcp_connect(...) to that port and verifies the returned file descriptor
+      is not file_invalid(). Cleans up sockets and joins server thread.
+
+    - test_tcp_connect_failure
+      Attempts to connect to a deliberately bogus hostname and expects tcp_connect
+      to return file_invalid().
+
+    - test_https_request_returns_initial_pointer_on_failed_resolve
+      Verifies https_request_sync returns the initial allocator cursor when tcp_connect
+      fails due to host resolution failure (no real network/SSL activity required).
+*/
+
+/* Thread argument for server thread */
+typedef struct tcp_server_thread_arg {
+    int listen_fd;
+} tcp_server_thread_arg;
+
+/* Server thread: accept one connection, optionally read a small amount, then close everything. */
+static void* tcp_server_thread(void* arg) {
+    tcp_server_thread_arg* a = (tcp_server_thread_arg*)arg;
+
+    struct sockaddr_storage client_addr;
+    socklen_t client_len = sizeof(client_addr);
+    int client_fd = accept(a->listen_fd, (struct sockaddr*)&client_addr, &client_len);
+    if (client_fd >= 0) {
+        /* Try to read a bit (non-critical) then close */
+        char buf[256];
+        ssize_t r = read(client_fd, buf, sizeof(buf));
+        unused(r);
+        close(client_fd);
+    }
+    close(a->listen_fd);
+    return NULL;
+}
+
+static void test_tcp_connect_success(test_context* t) {
+    /* Create listening socket bound to 127.0.0.1:0 (ephemeral port) */
+    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    TEST_ASSERT_EQUAL(t, (int)(listen_fd >= 0), 1);
+
+    int yes = 1;
+    setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); /* 127.0.0.1 */
+    addr.sin_port = 0; /* ephemeral */
+
+    int b = bind(listen_fd, (struct sockaddr*)&addr, sizeof(addr));
+    TEST_ASSERT_EQUAL(t, (int)(b == 0), 1);
+
+    int l = listen(listen_fd, 1);
+    TEST_ASSERT_EQUAL(t, (int)(l == 0), 1);
+
+    /* Retrieve chosen port */
+    struct sockaddr_in bound;
+    socklen_t bound_len = sizeof(bound);
+    int g = getsockname(listen_fd, (struct sockaddr*)&bound, &bound_len);
+    TEST_ASSERT_EQUAL(t, (int)(g == 0), 1);
+    uint16_t port = ntohs(bound.sin_port);
+
+    /* Start server thread that will accept one connection */
+    pthread_t thread;
+    tcp_server_thread_arg arg = { .listen_fd = listen_fd };
+    int pc = pthread_create(&thread, NULL, tcp_server_thread, &arg);
+    TEST_ASSERT_EQUAL(t, (int)(pc == 0), 1);
+
+    /* Prepare allocator for tcp_connect call */
+    uptr size = 64 * 1024;
+    void* pointer = mem_map(size);
+    TEST_ASSERT_EQUAL(t, (int)(pointer != NULL), 1);
+    stack_alloc alloc;
+    sa_init(&alloc, pointer, byteoffset(pointer, size));
+
+    /* Build u8_slice host and port */
+    u8 host_buf[] = "127.0.0.1";
+    u8 port_buf[16];
+    snprintf((char*)port_buf, sizeof(port_buf), "%u", (unsigned)port);
+
+    u8_slice host = { host_buf, byteoffset(host_buf, mem_cstrlen(host_buf)) };
+    u8_slice port_slice = { port_buf, byteoffset(port_buf, mem_cstrlen(port_buf)) };
+
+    /* Attempt to connect */
+    file_t conn = tcp_connect(host, port_slice, &alloc);
+
+    /* Expect success (not file_invalid) */
+    TEST_ASSERT_EQUAL(t, (int)(conn != file_invalid()), 1);
+
+    /* Close connection */
+    tcp_close(conn);
+
+    /* Join server thread */
+    pthread_join(thread, NULL);
+
+    /* Cleanup allocator */
+    sa_deinit(&alloc);
+    mem_unmap(pointer, size);
+}
+
+static void test_tcp_connect_failure(test_context* t) {
+    /* Prepare allocator */
+    uptr size = 32 * 1024;
+    void* pointer = mem_map(size);
+    TEST_ASSERT_EQUAL(t, (int)(pointer != NULL), 1);
+    stack_alloc alloc;
+    sa_init(&alloc, pointer, byteoffset(pointer, size));
+
+    /* Deliberately bogus hostname that should not resolve */
+    u8 host_buf[] = "no-such-hostname-for-unit-test.invalid";
+    u8 port_buf[] = "12345";
+
+    u8_slice host = { host_buf, byteoffset(host_buf, mem_cstrlen(host_buf)) };
+    u8_slice port_slice = { port_buf, byteoffset(port_buf, mem_cstrlen(port_buf)) };
+
+    file_t conn = tcp_connect(host, port_slice, &alloc);
+
+    /* Expect failure (file_invalid) */
+    TEST_ASSERT_EQUAL(t, (int)(conn == file_invalid()), 1);
+
+    sa_deinit(&alloc);
+    mem_unmap(pointer, size);
+}
+
+/* Test https_request_sync when tcp_connect fails (e.g. host cannot be resolved).
+   The function should cleanly return the initial allocator cursor (no crash). */
+static void test_https_request_returns_initial_pointer_on_failed_resolve(test_context* t) {
+    uptr size = 64 * 1024;
+    void* pointer = mem_map(size);
+    TEST_ASSERT_EQUAL(t, (int)(pointer != NULL), 1);
+    stack_alloc alloc;
+    sa_init(&alloc, pointer, byteoffset(pointer, size));
+
+    /* Save begin cursor */
+    void* begin = alloc.cursor;
+
+    u8 host_buf[] = "no-such-hostname-for-unit-test.invalid";
+    u8 port_buf[] = "443";
+    u8 req_buf[] = "GET / HTTP/1.0\r\nHost: no-such-hostname-for-unit-test.invalid\r\n\r\n";
+
+    u8_slice host = { host_buf, byteoffset(host_buf, mem_cstrlen(host_buf)) };
+    u8_slice port_slice = { port_buf, byteoffset(port_buf, mem_cstrlen(port_buf)) };
+    u8_slice request = { req_buf, byteoffset(req_buf, mem_cstrlen(req_buf)) };
+
+    void* res = https_request_sync(&alloc, host, port_slice, request);
+
+    /* The function returns the initial 'begin' pointer on cleanup; ensure it did not advance/alter unexpectedly */
+    TEST_ASSERT_EQUAL(t, (int)(res == begin), 1);
+
+    sa_deinit(&alloc);
+    mem_unmap(pointer, size);
+}
+
+void test_network_module(test_context* t) {
+    REGISTER_TEST(t, "tcp_connect_success", test_tcp_connect_success);
+    REGISTER_TEST(t, "tcp_connect_failure", test_tcp_connect_failure);
+    REGISTER_TEST(t, "https_request_return_on_failed_resolve", test_https_request_returns_initial_pointer_on_failed_resolve);
+}

--- a/tests/test_network.h
+++ b/tests/test_network.h
@@ -1,0 +1,9 @@
+#ifndef TEST_NETWORK_H
+#define TEST_NETWORK_H
+
+#include "test_framework.h"
+
+void test_network_module(test_context* t);
+
+#endif /*TEST_SNAKE_H*/
+


### PR DESCRIPTION
- Add test_network.c with TCP connect tests and HTTPS request failure edge case
- Add test_network.h and wire into all_tests and Makefile
- Include test_network in all_tests.c
- Extend test target to include NETWORK_LFLAGS and network_o in builds

Notes:
- Adds local epoll-free TCP server thread for test_tcp_connect_success
- Verifies behavior on connect failure and https_request behavior on failed resolution